### PR TITLE
feat/BR-4091/Add source header with 'magento' on all HTTP requests

### DIFF
--- a/Lib/Http/Client/Curl.php
+++ b/Lib/Http/Client/Curl.php
@@ -11,6 +11,8 @@
 
 namespace Balancepay\Balancepay\Lib\Http\Client;
 
+use Balancepay\Balancepay\Model\HttpConstants;
+
 class Curl extends \Magento\Framework\HTTP\Client\Curl
 {
     /**
@@ -117,11 +119,11 @@ class Curl extends \Magento\Framework\HTTP\Client\Curl
     protected function setPostParams(array $params)
     {
         $contentType = null;
-        if (!empty($this->_headers['Content-Type'])) {
-            $contentType = $this->_headers['Content-Type'];
+        if (!empty($this->_headers[HttpConstants::HEADER_CONTENT_TYPE])) {
+            $contentType = $this->_headers[HttpConstants::HEADER_CONTENT_TYPE];
         }
 
-        if ($contentType === 'application/json') {
+        if ($contentType === HttpConstants::CONTENT_TYPE_APPLICATION_JSON) {
             $params = json_encode($params);
         } else {
             $params = http_build_query($params);

--- a/Model/AbstractRequest.php
+++ b/Model/AbstractRequest.php
@@ -169,8 +169,10 @@ abstract class AbstractRequest extends AbstractApi implements RequestInterface
         $params = $this->getParams();
 
         $headers = [
-            'Content-Type' => 'application/json',
-            'x-api-key' => $this->_balancepayConfig->getApiKey(),
+            HttpConstants::HEADER_CONTENT_TYPE => HttpConstants::CONTENT_TYPE_APPLICATION_JSON,
+            HttpConstants::HEADER_BALANCE_X_API_KEY => $this->_balancepayConfig->getApiKey(),
+            HttpConstants::HEADER_BALANCE_SOURCE => HttpConstants::BALANCE_SOURCE_MAGENTO,
+
         ];
         $this->_curl->setHeaders($headers);
 

--- a/Model/HttpConstants.php
+++ b/Model/HttpConstants.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Balancepay\Balancepay\Model;
+
+class HttpConstants
+{
+    public const HEADER_CONTENT_TYPE = 'Content-Type';
+    public const HEADER_BALANCE_X_API_KEY = 'x-api-key';
+    public const HEADER_BALANCE_SOURCE = 'source';
+
+    public const CONTENT_TYPE_APPLICATION_JSON = 'application/json';
+    public const BALANCE_SOURCE_MAGENTO = 'magento';
+}


### PR DESCRIPTION
Closes #BR-4091 (https://blnce.atlassian.net/browse/BR-4091)

Adds a 'source' header with 'magento' value on all HTTP requests originating from the Magento extension.