### PR TITLE
fix/br-5564: Add explicit dependency on crypt library

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ php bin/magento cache:flush
 Download & place the contents of this repository under {YOUR-MAGENTO2-ROOT-DIR}/app/code/Balancepay/Balancepay  
 Then, run the following commands under your Magento 2 root dir:
 ```
+composer config repositories.Balancepay '{"type": "path", "url": "app/code/Balancepay/Balancepay"}'
+composer require "getbalance/magento2-module-balancepay @dev"
 php bin/magento maintenance:enable
 php bin/magento setup:upgrade
 php bin/magento setup:di:compile

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "getbalance/magento2-module-balancepay",
     "description": "Balance Payments For Magento 2",
     "require": {
-        "php": ">=5.6"
+        "php": ">=5.6",
+        "laminas/laminas-crypt": "^3.4.0"
     },
     "type": "magento2-module",
     "version": "1.4.0",


### PR DESCRIPTION
Add explicit dependency on crypt library, add to manual installation steps in README